### PR TITLE
Rename some functions to not conflict

### DIFF
--- a/mitlib-page-customization-metabox.php
+++ b/mitlib-page-customization-metabox.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/MITLibraries/mitlib-page-customization-metabox
  * Description: Adds a block of help text to a metabox on the page editing screen.
  * Author: MIT Libraries
- * Version: 1.0
+ * Version: 1.0.1
  * Author URI: https://github.com/MITLibraries
  * License: GPLv2
  *
@@ -36,16 +36,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds a meta box to the page editing screen
  */
-function prfx_custom_meta() {
-	add_meta_box( 'prfx_meta', __( 'Page Customization', 'prfx-textdomain' ), 'prfx_meta_callback', 'page', 'side', 'high' );
+function mitlib_page_customization_meta() {
+	add_meta_box( 'mitlib_page_customization_meta', __( 'Page Customization', 'prfx-textdomain' ), 'mitlib_page_customization_meta_callback', 'page', 'side', 'high' );
 }
-add_action( 'add_meta_boxes', 'prfx_custom_meta' );
+add_action( 'add_meta_boxes', 'mitlib_page_customization_meta' );
 
 /**
  * Outputs the content of the meta box
  *
  * @param object $post unused.
  */
-function prfx_meta_callback( $post ) {
-	echo 'To customize the breadcrumb and the link to the top-level category at the top of the page, see the <b>Categories</b> box below.';
+function mitlib_page_customization_meta_callback( $post ) {
+	echo 'To customize the breadcrumb and the link to the top-level category at the top of the page, see the <strong>Categories</strong> box below.';
 }


### PR DESCRIPTION
The first time I tried enabling this locally, the application crashed. This was because of some naming collisions with a prior implementation of this metabox.

This PR changes those function names, and references to them.

It also updates a `b` tag to a `strong` tag, as a smoke test to make sure the new functions are being called.